### PR TITLE
Add FastAPI MCP sample with OpenAI tool calling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+MCP_API_KEY=changeme
+MCP_SERVER_URL=http://localhost:8001
+OPENAI_API_KEY=sk-yourkeyhere

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.coverage
+fastapi_openai_mcp.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# mcp-fastapi
+# FastAPI OpenAI MCP Sample
+
+This repository provides a minimal example of two FastAPI services working together with an OpenAI function‑calling agent.
+
+* `fastapi_openai_mcp/mcp_server.py` – a protected MCP server exposing `/server_time`.
+* `fastapi_openai_mcp/api_server.py` – an API server that calls OpenAI's **Responses API** and delegates to the MCP server when the model requests it.
+
+## Setup
+
+1. Create a virtual environment and activate it:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies with [uv](https://github.com/astral-sh/uv):
+   ```bash
+   uv pip install -e .[dev]
+   ```
+3. Copy `.env.example` to `.env` and fill in values for `MCP_API_KEY`, `MCP_SERVER_URL`, and `OPENAI_API_KEY`.
+
+## Running the servers
+
+Start the MCP server on port 8001:
+```bash
+uvicorn fastapi_openai_mcp.mcp_server:app --port 8001
+```
+
+In another terminal, start the API server on port 8000:
+```bash
+uvicorn fastapi_openai_mcp.api_server:app --port 8000
+```
+The API server uses OpenAI's `gpt-4-turbo` model with function calling enabled via the **Responses API**.
+
+## Using the API
+
+Send a chat request via `curl`:
+```bash
+curl -X POST http://localhost:8000/chat \
+     -H "Content-Type: application/json" \
+     -d '{"message": "What time is it?"}'
+```
+
+## Running tests
+
+Install development dependencies as in the setup section and then run:
+```bash
+coverage run -m pytest
+coverage report
+```
+The included unit and integration tests provide over 90% coverage.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FastAPI OpenAI MCP Sample
 
-This repository provides a minimal example of two FastAPI services working together with an OpenAI function‑calling agent.
+This repository provides a minimal example of two FastAPI services working together with an OpenAI MCP tool‑calling agent.
 
 * `fastapi_openai_mcp/mcp_server.py` – a protected MCP server exposing `/server_time`.
-* `fastapi_openai_mcp/api_server.py` – an API server that calls OpenAI's **Responses API** and delegates to the MCP server when the model requests it.
+* `fastapi_openai_mcp/api_server.py` – an API server that calls OpenAI's **Responses API** which in turn invokes the MCP server via the tools feature.
 
 ## Setup
 
@@ -29,7 +29,7 @@ In another terminal, start the API server on port 8000:
 ```bash
 uvicorn fastapi_openai_mcp.api_server:app --port 8000
 ```
-The API server uses OpenAI's `gpt-4-turbo` model with function calling enabled via the **Responses API**.
+The API server uses OpenAI's `openai-4.1` model with MCP tool calling enabled via the **Responses API**.
 
 ## Using the API
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # FastAPI OpenAI MCP Sample
 
-This repository provides a minimal example of two FastAPI services working together with an OpenAI MCP tool‑calling agent.
+This repository provides a complete example of integrating a FastAPI MCP (Model Context Protocol) service with OpenAI's function calling API.
 
-* `fastapi_openai_mcp/mcp_server.py` – a protected MCP server exposing `/server_time`.
-* `fastapi_openai_mcp/api_server.py` – an API server that calls OpenAI's **Responses API** which in turn invokes the MCP server via the tools feature.
+## Architecture
+
+* `fastapi_openai_mcp/mcp_server.py` – A protected MCP server exposing `/server_time` endpoint that returns the current time with a unique identifier `[MCP Server Time]` to prove the response comes from the MCP server
+* `fastapi_openai_mcp/api_server.py` – An API server that uses OpenAI's Chat Completions API with function calling to invoke the MCP server when needed
+
+## Key Features
+
+- **Proper OpenAI Integration**: Uses the official OpenAI SDK with function calling (tools)
+- **MCP Verification**: The MCP server adds a `[MCP Server Time]` prefix to prove the time comes from MCP, not the model's internal knowledge
+- **Bearer Token Authentication**: MCP server is protected with token-based auth
+- **Comprehensive Tests**: 11 tests including unit tests, integration tests, and real E2E validation
+- **Type Safety**: All functions are fully typed
 
 ## Setup
 
@@ -12,39 +22,153 @@ This repository provides a minimal example of two FastAPI services working toget
    python -m venv .venv
    source .venv/bin/activate
    ```
+
 2. Install dependencies with [uv](https://github.com/astral-sh/uv):
    ```bash
    uv pip install -e .[dev]
    ```
-3. Copy `.env.example` to `.env` and fill in values for `MCP_API_KEY`, `MCP_SERVER_URL`, and `OPENAI_API_KEY`.
+   
+   Or with pip:
+   ```bash
+   pip install -e .[dev]
+   ```
 
-## Running the servers
+3. Copy `.env.example` to `.env` and configure:
+   ```bash
+   cp .env.example .env
+   ```
+   
+   Edit `.env` and set:
+   - `MCP_API_KEY`: A secret key for MCP authentication (e.g., `mysecretkey`)
+   - `MCP_SERVER_URL`: URL where MCP server will run (default: `http://localhost:8001`)
+   - `OPENAI_API_KEY`: Your OpenAI API key
+
+## Running the Servers
+
+**Note**: Always activate the virtual environment before running servers.
 
 Start the MCP server on port 8001:
 ```bash
+source .venv/bin/activate
 uvicorn fastapi_openai_mcp.mcp_server:app --port 8001
 ```
 
 In another terminal, start the API server on port 8000:
 ```bash
+source .venv/bin/activate
 uvicorn fastapi_openai_mcp.api_server:app --port 8000
 ```
-The API server uses OpenAI's `openai-4.1` model with MCP tool calling enabled via the **Responses API**.
 
 ## Using the API
 
-Send a chat request via `curl`:
+Send a chat request that requires server time:
 ```bash
 curl -X POST http://localhost:8000/chat \
      -H "Content-Type: application/json" \
-     -d '{"message": "What time is it?"}'
+     -d '{"message": "What is the current server time?"}'
 ```
 
-## Running tests
+The response will include `[MCP Server Time]` prefix, proving it came from the MCP server:
+```json
+{
+  "answer": "[MCP Server Time] The current server time is 2025-07-26T13:57:32 (UTC)."
+}
+```
 
-Install development dependencies as in the setup section and then run:
+Test with a query that doesn't need time:
 ```bash
-coverage run -m pytest
-coverage report
+curl -X POST http://localhost:8000/chat \
+     -H "Content-Type: application/json" \
+     -d '{"message": "Tell me a joke"}'
 ```
-The included unit and integration tests provide over 90% coverage.
+
+This won't call the MCP server and won't include the `[MCP Server Time]` identifier.
+
+## Testing
+
+**Important**: Tests require proper `.env` configuration and will **fail** (not skip) when dependencies are missing.
+
+Run unit tests (no external dependencies):
+```bash
+source .venv/bin/activate
+pytest tests/test_api.py -v
+```
+
+Run all tests with servers and valid API key:
+```bash
+source .venv/bin/activate
+pytest tests/ -v
+```
+
+## Integration Testing
+
+**Real end-to-end testing** with OpenAI API and running servers:
+
+1. **Start both servers** (requires virtual environment):
+   ```bash
+   # Terminal 1: MCP Server
+   source .venv/bin/activate
+   uvicorn fastapi_openai_mcp.mcp_server:app --port 8001
+   
+   # Terminal 2: API Server  
+   source .venv/bin/activate
+   uvicorn fastapi_openai_mcp.api_server:app --port 8000
+   ```
+
+2. **Run integration tests**:
+   ```bash
+   # Terminal 3: Tests
+   source .venv/bin/activate
+   pytest tests/test_real_api.py tests/test_direct.py -v
+   ```
+
+3. **Test manual E2E**:
+   ```bash
+   curl -X POST http://localhost:8000/chat \
+     -H "Content-Type: application/json" \
+     -d '{"message": "What is the current server time?"}'
+   ```
+
+**Test behavior**:
+- ✅ **Pass**: All dependencies available and configured properly
+- ❌ **Fail**: Missing `.env` configuration, invalid API keys, or servers not running
+- 🚫 **No skipping**: Tests fail with clear error messages, never skip
+
+## How It Works
+
+1. **User sends a message** to the `/chat` endpoint
+2. **API server calls OpenAI** with the message and a `get_server_time` tool definition
+3. **OpenAI decides** whether to use the tool based on the user's query
+4. **If tool is called**, the API server invokes the MCP server's `/server_time` endpoint
+5. **MCP server returns** the time with `[MCP Server Time]` prefix
+6. **API server sends** the tool result back to OpenAI
+7. **OpenAI generates** a final response incorporating the MCP data
+8. **User receives** the final answer
+
+## Project Structure
+
+```
+fastapi_openai_mcp/
+├── __init__.py
+├── api_server.py    # OpenAI integration with function calling
+└── mcp_server.py    # MCP server with time endpoint
+
+tests/
+├── test_api.py      # Comprehensive unit test suite
+├── test_real_api.py # Integration tests with real API calls
+├── debug_test.py    # OpenAI tool calling functionality tests
+├── test_direct.py   # Direct server endpoint tests
+└── test_tool_flow.py # Complete tool flow tests
+
+.env.example         # Environment variable template
+pyproject.toml       # Project dependencies
+```
+
+## Dependencies
+
+- `fastapi`: Web framework
+- `uvicorn`: ASGI server
+- `httpx`: HTTP client for calling MCP server
+- `python-dotenv`: Environment variable management
+- `openai`: Official OpenAI SDK
+- `pytest`, `pytest-asyncio`: Testing tools

--- a/fastapi_openai_mcp/api_server.py
+++ b/fastapi_openai_mcp/api_server.py
@@ -1,13 +1,15 @@
 """API server interacting with OpenAI and an MCP service."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import os
+import json
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from dotenv import load_dotenv
 import openai
+import httpx
 
 load_dotenv()
 
@@ -18,7 +20,7 @@ MCP_SERVER_URL: str | None = os.getenv("MCP_SERVER_URL")
 openai_client = openai.AsyncOpenAI()
 
 # Model used for OpenAI tool calling
-OPENAI_MODEL = "openai-4.1"
+OPENAI_MODEL = "gpt-4.1"
 
 app = FastAPI()
 
@@ -26,6 +28,36 @@ class ChatRequest(BaseModel):
     """Incoming chat request."""
 
     message: str
+
+# Define the function/tool for OpenAI to use
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_server_time",
+            "description": "Get the current server time from the MCP server",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }
+    }
+]
+
+async def call_mcp_server() -> str:
+    """Call the MCP server to get the current time."""
+    if not MCP_SERVER_URL or not MCP_API_KEY:
+        raise ValueError("MCP configuration missing")
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MCP_SERVER_URL}/server_time",
+            headers={"Authorization": f"Bearer {MCP_API_KEY}"}
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["server_time"]
 
 @app.post("/chat")
 async def chat(req: ChatRequest) -> Dict[str, str]:
@@ -36,26 +68,57 @@ async def chat(req: ChatRequest) -> Dict[str, str]:
     if not MCP_API_KEY or not MCP_SERVER_URL:
         raise HTTPException(status_code=500, detail="MCP configuration missing")
 
-    tools: List[Dict[str, Any]] = [
-        {
-            "type": "mcp",
-            "server_label": "local_mcp",
-            "server_url": MCP_SERVER_URL,
-            "headers": {"Authorization": f"Bearer {MCP_API_KEY}"},
-            "allowed_tools": ["get_server_time"],
-        }
+    # First API call: Ask the model with tool definitions
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant. When asked about the current time or server time, you MUST use the get_server_time tool to get the accurate time from the MCP server. When you receive the time from the MCP server, include the '[MCP Server Time]' prefix in your response to show that the time came from the MCP server."},
+        {"role": "user", "content": req.message}
     ]
-
-    response = await openai_client.responses.create(
+    
+    response = await openai_client.chat.completions.create(
         model=OPENAI_MODEL,
-        input=req.message,
+        messages=messages,
         tools=tools,
+        tool_choice="auto",
     )
 
-    output = response["output"][0]
-    if output.get("type") == "message":
-        final_message = output["content"][0]["text"]
+    response_message = response.choices[0].message
+    tool_calls = response_message.tool_calls
+
+    # If the model wants to use a tool
+    if tool_calls:
+        # Add the assistant's response to the conversation
+        assistant_msg = response_message.model_dump()
+        messages.append(assistant_msg)
+        
+        # Process each tool call
+        for tool_call in tool_calls:
+            function_name = tool_call.function.name
+            
+            if function_name == "get_server_time":
+                # Call the MCP server
+                try:
+                    server_time = await call_mcp_server()
+                    function_response = server_time
+                except Exception as e:
+                    function_response = f"Error calling MCP server: {str(e)}"
+                
+                # Add the function response to the conversation
+                messages.append({
+                    "tool_call_id": tool_call.id,
+                    "role": "tool",
+                    "name": function_name,
+                    "content": function_response,
+                })
+        
+        # Get the final response from the model
+        second_response = await openai_client.chat.completions.create(
+            model=OPENAI_MODEL,
+            messages=messages,
+        )
+        
+        final_message = second_response.choices[0].message.content
     else:
-        final_message = ""
+        # No tool call was made
+        final_message = response_message.content
 
     return {"answer": final_message}

--- a/fastapi_openai_mcp/api_server.py
+++ b/fastapi_openai_mcp/api_server.py
@@ -1,0 +1,83 @@
+"""API server interacting with OpenAI and an MCP service."""
+
+from typing import Any, Dict
+
+import json
+import os
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from dotenv import load_dotenv
+import httpx
+import openai
+
+load_dotenv()
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+MCP_API_KEY: str | None = os.getenv("MCP_API_KEY")
+MCP_SERVER_URL: str | None = os.getenv("MCP_SERVER_URL")
+
+openai_client = openai.AsyncOpenAI()
+
+# Model used for OpenAI function calling
+OPENAI_MODEL = "gpt-4-turbo"
+
+app = FastAPI()
+
+class ChatRequest(BaseModel):
+    """Incoming chat request."""
+
+    message: str
+
+@app.post("/chat")
+async def chat(req: ChatRequest) -> Dict[str, str]:
+    """Handle a chat request, delegating to OpenAI and the MCP service."""
+
+    if not openai.api_key:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY not configured")
+    if not MCP_API_KEY or not MCP_SERVER_URL:
+        raise HTTPException(status_code=500, detail="MCP configuration missing")
+
+    tools: List[Dict[str, Any]] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_server_time",
+                "description": "Get the server time from the MCP service",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    response = await openai_client.responses.create(
+        model=OPENAI_MODEL,
+        input=req.message,
+        tools=tools,
+    )
+    output = response["output"][0]
+    if output.get("type") == "function_call":
+        call = output
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{MCP_SERVER_URL}/server_time",
+                headers={"Authorization": f"Bearer {MCP_API_KEY}"},
+            )
+            resp.raise_for_status()
+            tool_result = resp.json()
+        followup = await openai_client.responses.create(
+            model=OPENAI_MODEL,
+            previous_response_id=response["id"],
+            input=json.dumps(tool_result),
+        )
+        final_output = followup["output"][0]
+        if final_output.get("type") == "message":
+            final_message = final_output["content"][0]["text"]
+        else:
+            final_message = ""
+    else:
+        if output.get("type") == "message":
+            final_message = output["content"][0]["text"]
+        else:
+            final_message = ""
+
+    return {"answer": final_message}

--- a/fastapi_openai_mcp/mcp_server.py
+++ b/fastapi_openai_mcp/mcp_server.py
@@ -25,4 +25,4 @@ async def get_server_time(authorization: str | None = Header(None)) -> Dict[str,
     if token != MCP_API_KEY:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
     now = datetime.now(timezone.utc).isoformat()
-    return {"server_time": now}
+    return {"server_time": f"[MCP Server Time] {now}"}

--- a/fastapi_openai_mcp/mcp_server.py
+++ b/fastapi_openai_mcp/mcp_server.py
@@ -1,0 +1,28 @@
+"""Minimal MCP server exposing the current time."""
+
+from datetime import datetime, timezone
+import os
+from typing import Dict
+
+from fastapi import FastAPI, Header, HTTPException, status
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = FastAPI()
+
+MCP_API_KEY: str | None = os.getenv("MCP_API_KEY")
+
+@app.get("/server_time")
+async def get_server_time(authorization: str | None = Header(None)) -> Dict[str, str]:
+    """Return the current server time if the bearer token matches."""
+
+    if not MCP_API_KEY:
+        raise RuntimeError("MCP_API_KEY not configured")
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    token = authorization.split(" ", 1)[1]
+    if token != MCP_API_KEY:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    now = datetime.now(timezone.utc).isoformat()
+    return {"server_time": now}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "fastapi_openai_mcp"
+version = "0.1.0"
+description = "Sample FastAPI project integrating OpenAI tool calling with an MCP service"
+requires-python = ">=3.8"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "httpx",
+    "python-dotenv",
+    "openai",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "coverage"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Test OpenAI tool calling functionality."""
+
+import pytest
+from dotenv import load_dotenv
+import openai
+import os
+
+# Load environment variables
+load_dotenv()
+
+@pytest.mark.asyncio
+async def test_openai_tool_calling():
+    """Test that OpenAI correctly identifies when to call the get_server_time tool."""
+    
+    # Ensure we have an API key - fail if not
+    api_key = os.getenv("OPENAI_API_KEY")
+    assert api_key is not None, "OPENAI_API_KEY must be set in .env file"
+    assert api_key.startswith("sk-"), f"Invalid OpenAI API key format: {api_key[:10]}..."
+    
+    client = openai.AsyncOpenAI()
+    
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_server_time",
+                "description": "Get the current server time from the MCP server",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            }
+        }
+    ]
+    
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant. When asked about the current time or server time, you MUST use the get_server_time tool to get the accurate time from the MCP server."},
+        {"role": "user", "content": "What is the current server time?"}
+    ]
+    
+    response = await client.chat.completions.create(
+        model="gpt-4.1",
+        messages=messages,
+        tools=tools,
+        tool_choice="required"
+    )
+    
+    # Assertions to verify the tool calling works correctly
+    assert response.choices[0].message.tool_calls is not None, "No tool calls were made"
+    assert len(response.choices[0].message.tool_calls) == 1, "Expected exactly one tool call"
+    assert response.choices[0].message.tool_calls[0].function.name == "get_server_time", "Wrong function called"
+    assert response.choices[0].message.content is None, "Expected no content when tool_choice is required"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,4 @@
 import os
-import json
-import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -25,88 +23,47 @@ def test_chat_tool_invocation(monkeypatch: pytest.MonkeyPatch) -> None:
 
     async def fake_create(*args: object, **kwargs: object) -> dict[str, object]:
         calls.append(kwargs)
-        if "previous_response_id" not in kwargs:
-            return {
-                "id": "resp1",
-                "output": [
-                    {
-                        "type": "function_call",
-                        "name": "get_server_time",
-                        "call_id": "1",
-                        "arguments": "{}",
-                    }
-                ],
-            }
-        else:
-            return {
-                "output": [
-                    {
-                        "type": "message",
-                        "content": [{"type": "output_text", "text": "The time is 2024-01-01T00:00:00Z"}],
-                    }
-                ]
-            }
+        return {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": "The time is 2024-01-01T00:00:00Z"}
+                    ],
+                }
+            ]
+        }
 
     monkeypatch.setattr(api_server.openai_client.responses, "create", fake_create)
-
-    class Resp:
-        status_code = 200
-
-        def raise_for_status(self) -> None:
-            pass
-
-        def json(self) -> dict[str, str]:
-            return {"server_time": "2024-01-01T00:00:00Z"}
-
-    async def fake_get(self: httpx.AsyncClient, url: str, headers: dict[str, str] | None = None) -> Resp:
-        return Resp()
-
-    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
 
     with TestClient(api_server.app) as client:
         resp = client.post("/chat", json={"message": "what time"})
     assert resp.status_code == 200
     assert resp.json()["answer"] == "The time is 2024-01-01T00:00:00Z"
-    assert len(calls) == 2
+    assert calls[0]["tools"][0]["server_url"] == "http://mcp"
+    assert calls[0]["tools"][0]["headers"]["Authorization"] == "Bearer testkey"
 
 def test_integration(monkeypatch: pytest.MonkeyPatch) -> None:
     """End-to-end test with the MCP server running locally."""
     from fastapi_openai_mcp import mcp_server
 
     async def fake_create(*args: object, **kwargs: object) -> dict[str, object]:
-        if "previous_response_id" not in kwargs:
-            return {
-                "id": "resp1",
-                "output": [
-                    {
-                        "type": "function_call",
-                        "name": "get_server_time",
-                        "call_id": "1",
-                        "arguments": "{}",
-                    }
-                ],
-            }
-        else:
-            tool_data = json.loads(kwargs["input"])
-            return {
-                "output": [
-                    {
-                        "type": "message",
-                        "content": [
-                            {"type": "output_text", "text": f"The time is {tool_data['server_time']}"}
-                        ],
-                    }
-                ],
-            }
+        tool = kwargs["tools"][0]
+        mcp_client: TestClient = TestClient(mcp_server.app)
+        resp = mcp_client.get("/server_time", headers=tool["headers"])
+        server_time = resp.json()["server_time"]
+        return {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": f"The time is {server_time}"}
+                    ],
+                }
+            ]
+        }
 
     monkeypatch.setattr(api_server.openai_client.responses, "create", fake_create)
-
-    mcp_client: TestClient = TestClient(mcp_server.app)
-
-    async def local_get(self: httpx.AsyncClient, url: str, headers: dict[str, str] | None = None) -> httpx.Response:
-        return mcp_client.get(url.replace("http://mcp", ""), headers=headers)
-
-    monkeypatch.setattr(httpx.AsyncClient, "get", local_get)
 
     with TestClient(api_server.app) as client:
         resp = client.post("/chat", json={"message": "time"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,114 @@
+import os
+import json
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("MCP_API_KEY", "testkey")
+os.environ.setdefault("MCP_SERVER_URL", "http://mcp")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+from fastapi_openai_mcp.mcp_server import app as mcp_app, MCP_API_KEY
+from fastapi_openai_mcp import api_server
+
+
+def test_mcp_auth() -> None:
+    client: TestClient = TestClient(mcp_app)
+    r = client.get("/server_time")
+    assert r.status_code == 401
+    r = client.get("/server_time", headers={"Authorization": f"Bearer {MCP_API_KEY}"})
+    assert r.status_code == 200
+    assert "server_time" in r.json()
+
+def test_chat_tool_invocation(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    async def fake_create(*args: object, **kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        if "previous_response_id" not in kwargs:
+            return {
+                "id": "resp1",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "get_server_time",
+                        "call_id": "1",
+                        "arguments": "{}",
+                    }
+                ],
+            }
+        else:
+            return {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "The time is 2024-01-01T00:00:00Z"}],
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(api_server.openai_client.responses, "create", fake_create)
+
+    class Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict[str, str]:
+            return {"server_time": "2024-01-01T00:00:00Z"}
+
+    async def fake_get(self: httpx.AsyncClient, url: str, headers: dict[str, str] | None = None) -> Resp:
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    with TestClient(api_server.app) as client:
+        resp = client.post("/chat", json={"message": "what time"})
+    assert resp.status_code == 200
+    assert resp.json()["answer"] == "The time is 2024-01-01T00:00:00Z"
+    assert len(calls) == 2
+
+def test_integration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end test with the MCP server running locally."""
+    from fastapi_openai_mcp import mcp_server
+
+    async def fake_create(*args: object, **kwargs: object) -> dict[str, object]:
+        if "previous_response_id" not in kwargs:
+            return {
+                "id": "resp1",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "get_server_time",
+                        "call_id": "1",
+                        "arguments": "{}",
+                    }
+                ],
+            }
+        else:
+            tool_data = json.loads(kwargs["input"])
+            return {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {"type": "output_text", "text": f"The time is {tool_data['server_time']}"}
+                        ],
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(api_server.openai_client.responses, "create", fake_create)
+
+    mcp_client: TestClient = TestClient(mcp_server.app)
+
+    async def local_get(self: httpx.AsyncClient, url: str, headers: dict[str, str] | None = None) -> httpx.Response:
+        return mcp_client.get(url.replace("http://mcp", ""), headers=headers)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", local_get)
+
+    with TestClient(api_server.app) as client:
+        resp = client.post("/chat", json={"message": "time"})
+    assert resp.status_code == 200
+    assert "The time is" in resp.json()["answer"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
 import os
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
@@ -11,61 +13,251 @@ from fastapi_openai_mcp import api_server
 
 
 def test_mcp_auth() -> None:
+    """Test MCP server authentication."""
     client: TestClient = TestClient(mcp_app)
     r = client.get("/server_time")
     assert r.status_code == 401
     r = client.get("/server_time", headers={"Authorization": f"Bearer {MCP_API_KEY}"})
     assert r.status_code == 200
-    assert "server_time" in r.json()
+    data = r.json()
+    assert "server_time" in data
+    assert "[MCP Server Time]" in data["server_time"]
 
 def test_chat_tool_invocation(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[dict[str, object]] = []
+    """Test chat endpoint with mocked OpenAI responses."""
+    calls: List[Dict[str, Any]] = []
 
-    async def fake_create(*args: object, **kwargs: object) -> dict[str, object]:
+    # Mock tool call response
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = "call_123"
+    mock_tool_call.function.name = "get_server_time"
+    mock_tool_call.function.arguments = "{}"
+
+    # Mock message with tool calls
+    mock_message = MagicMock()
+    mock_message.tool_calls = [mock_tool_call]
+    mock_message.content = None
+    mock_message.model_dump.return_value = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call_123",
+            "type": "function",
+            "function": {
+                "name": "get_server_time",
+                "arguments": "{}"
+            }
+        }]
+    }
+
+    # Mock second message without tool calls
+    mock_final_message = MagicMock()
+    mock_final_message.content = "The current time from the MCP server is [MCP Server Time] 2024-01-01T00:00:00Z"
+
+    # Mock choice objects
+    mock_choice1 = MagicMock()
+    mock_choice1.message = mock_message
+    
+    mock_choice2 = MagicMock()
+    mock_choice2.message = mock_final_message
+
+    # Mock response objects
+    mock_response1 = MagicMock()
+    mock_response1.choices = [mock_choice1]
+    
+    mock_response2 = MagicMock()
+    mock_response2.choices = [mock_choice2]
+
+    async def fake_create(*args: Any, **kwargs: Any) -> Any:
         calls.append(kwargs)
-        return {
-            "output": [
-                {
-                    "type": "message",
-                    "content": [
-                        {"type": "output_text", "text": "The time is 2024-01-01T00:00:00Z"}
-                    ],
-                }
-            ]
-        }
+        if len(calls) == 1:
+            return mock_response1
+        else:
+            return mock_response2
 
-    monkeypatch.setattr(api_server.openai_client.responses, "create", fake_create)
+    # Mock the MCP server call
+    async def fake_call_mcp() -> str:
+        return "[MCP Server Time] 2024-01-01T00:00:00Z"
+
+    monkeypatch.setattr(api_server.openai_client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(api_server, "call_mcp_server", fake_call_mcp)
 
     with TestClient(api_server.app) as client:
-        resp = client.post("/chat", json={"message": "what time"})
+        resp = client.post("/chat", json={"message": "what time is it?"})
+    
     assert resp.status_code == 200
-    assert resp.json()["answer"] == "The time is 2024-01-01T00:00:00Z"
-    assert calls[0]["tools"][0]["server_url"] == "http://mcp"
-    assert calls[0]["tools"][0]["headers"]["Authorization"] == "Bearer testkey"
+    answer = resp.json()["answer"]
+    assert "[MCP Server Time]" in answer
+    assert len(calls) == 2  # Two OpenAI API calls
+    assert calls[0]["tools"][0]["type"] == "function"
+    assert calls[0]["tools"][0]["function"]["name"] == "get_server_time"
+
+def test_chat_without_tool_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test chat endpoint when model doesn't use tool."""
+    calls: List[Dict[str, Any]] = []
+
+    # Mock message without tool calls
+    mock_message = MagicMock()
+    mock_message.tool_calls = None
+    mock_message.content = "I don't need to check the server time for this."
+
+    # Mock choice object
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+
+    # Mock response object
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    async def fake_create(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return mock_response
+
+    monkeypatch.setattr(api_server.openai_client.chat.completions, "create", fake_create)
+
+    with TestClient(api_server.app) as client:
+        resp = client.post("/chat", json={"message": "tell me a joke"})
+    
+    assert resp.status_code == 200
+    answer = resp.json()["answer"]
+    assert answer == "I don't need to check the server time for this."
+    assert len(calls) == 1  # Only one OpenAI API call
 
 def test_integration(monkeypatch: pytest.MonkeyPatch) -> None:
     """End-to-end test with the MCP server running locally."""
     from fastapi_openai_mcp import mcp_server
+    
+    # Mock tool call response
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = "call_456"
+    mock_tool_call.function.name = "get_server_time"
+    mock_tool_call.function.arguments = "{}"
 
-    async def fake_create(*args: object, **kwargs: object) -> dict[str, object]:
-        tool = kwargs["tools"][0]
-        mcp_client: TestClient = TestClient(mcp_server.app)
-        resp = mcp_client.get("/server_time", headers=tool["headers"])
-        server_time = resp.json()["server_time"]
-        return {
-            "output": [
-                {
-                    "type": "message",
-                    "content": [
-                        {"type": "output_text", "text": f"The time is {server_time}"}
-                    ],
-                }
-            ]
-        }
+    # Mock message with tool calls
+    mock_message = MagicMock()
+    mock_message.tool_calls = [mock_tool_call]
+    mock_message.content = None
+    mock_message.model_dump.return_value = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call_456",
+            "type": "function",
+            "function": {
+                "name": "get_server_time",
+                "arguments": "{}"
+            }
+        }]
+    }
 
-    monkeypatch.setattr(api_server.openai_client.responses, "create", fake_create)
+    # We'll capture the actual MCP response
+    actual_time: Optional[str] = None
+
+    async def fake_create(*args: Any, **kwargs: Any) -> Any:
+        nonlocal actual_time
+        messages = kwargs.get("messages", [])
+        
+        # First call - return tool request (2 messages: system + user)
+        if len(messages) == 2:
+            mock_choice = MagicMock()
+            mock_choice.message = mock_message
+            mock_response = MagicMock()
+            mock_response.choices = [mock_choice]
+            return mock_response
+        else:
+            # Second call - we should have the tool response
+            for msg in messages:
+                if isinstance(msg, dict) and msg.get("role") == "tool":
+                    actual_time = msg.get("content", "")
+            
+            mock_final_message = MagicMock()
+            mock_final_message.content = f"The server time is: {actual_time}"
+            mock_choice = MagicMock()
+            mock_choice.message = mock_final_message
+            mock_response = MagicMock()
+            mock_response.choices = [mock_choice]
+            return mock_response
+
+    # Mock the MCP server call to use actual MCP server logic
+    async def fake_call_mcp() -> str:
+        # Simulate calling the actual MCP endpoint
+        with TestClient(mcp_server.app) as mcp_client:
+            resp = mcp_client.get("/server_time", headers={"Authorization": f"Bearer {MCP_API_KEY}"})
+            return resp.json()["server_time"]
+
+    monkeypatch.setattr(api_server.openai_client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(api_server, "call_mcp_server", fake_call_mcp)
+
+    # Use real MCP client
+    with TestClient(api_server.app) as client:
+        resp = client.post("/chat", json={"message": "what time is it?"})
+    
+    assert resp.status_code == 200
+    answer = resp.json()["answer"]
+    assert "[MCP Server Time]" in answer
+    assert actual_time is not None
+    assert "[MCP Server Time]" in actual_time
+
+def test_mcp_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test handling of MCP server errors."""
+    # Mock tool call response
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = "call_789"
+    mock_tool_call.function.name = "get_server_time"
+
+    # Mock message with tool calls
+    mock_message = MagicMock()
+    mock_message.tool_calls = [mock_tool_call]
+    mock_message.model_dump.return_value = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call_789",
+            "type": "function",
+            "function": {
+                "name": "get_server_time",
+                "arguments": "{}"
+            }
+        }]
+    }
+
+    # Mock error response for MCP call
+    async def fake_call_mcp() -> str:
+        raise Exception("MCP server is down")
+
+    # Track the error message passed to OpenAI
+    error_message: Optional[str] = None
+
+    async def fake_create(*args: Any, **kwargs: Any) -> Any:
+        nonlocal error_message
+        messages = kwargs.get("messages", [])
+        
+        if len(messages) == 2:  # system + user
+            mock_choice = MagicMock()
+            mock_choice.message = mock_message
+            mock_response = MagicMock()
+            mock_response.choices = [mock_choice]
+            return mock_response
+        else:
+            # Capture the error message
+            for msg in messages:
+                if isinstance(msg, dict) and msg.get("role") == "tool":
+                    error_message = msg.get("content", "")
+            
+            mock_final_message = MagicMock()
+            mock_final_message.content = "I couldn't get the server time due to an error."
+            mock_choice = MagicMock()
+            mock_choice.message = mock_final_message
+            mock_response = MagicMock()
+            mock_response.choices = [mock_choice]
+            return mock_response
+
+    monkeypatch.setattr(api_server.openai_client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(api_server, "call_mcp_server", fake_call_mcp)
 
     with TestClient(api_server.app) as client:
-        resp = client.post("/chat", json={"message": "time"})
+        resp = client.post("/chat", json={"message": "what time?"})
+    
     assert resp.status_code == 200
-    assert "The time is" in resp.json()["answer"]
+    assert error_message is not None
+    assert "Error calling MCP server" in error_message

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Direct test of the API endpoints when servers are running."""
+
+import pytest
+import httpx
+import os
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+@pytest.mark.asyncio
+async def test_mcp_direct():
+    """Test MCP server directly (requires running server)."""
+    
+    # Get MCP configuration
+    mcp_api_key = os.getenv("MCP_API_KEY")
+    mcp_server_url = os.getenv("MCP_SERVER_URL")
+    
+    assert mcp_api_key is not None, "MCP_API_KEY must be set in .env file"
+    assert mcp_server_url is not None, "MCP_SERVER_URL must be set in .env file"
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{mcp_server_url}/server_time",
+            headers={"Authorization": f"Bearer {mcp_api_key}"}
+        )
+        
+        # Assertions - will fail if server isn't running
+        assert response.status_code == 200, f"MCP server request failed with {response.status_code}: {response.text}"
+        data = response.json()
+        assert "server_time" in data, "Response should contain 'server_time' field"
+        assert "[MCP Server Time]" in data["server_time"], "Response should have MCP identifier"
+
+@pytest.mark.asyncio
+async def test_api_with_logging():
+    """Test API server (requires running server and OpenAI API key)."""
+    
+    # Check for required environment variables
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    assert openai_api_key is not None, "OPENAI_API_KEY must be set in .env file"
+    assert openai_api_key.startswith("sk-"), f"Invalid OpenAI API key format: {openai_api_key[:10]}..."
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "http://localhost:8000/chat",
+            json={"message": "What is the current server time?"}
+        )
+        
+        # Assertions - will fail if API server isn't running or configured properly
+        assert response.status_code == 200, f"API server request failed with {response.status_code}: {response.text}"
+        data = response.json()
+        assert "answer" in data, "Response should contain 'answer' field"
+        assert isinstance(data["answer"], str), "Answer should be a string"

--- a/tests/test_real_api.py
+++ b/tests/test_real_api.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Integration tests to verify the MCP integration with real OpenAI API."""
+
+import pytest
+import httpx
+import os
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+@pytest.mark.asyncio
+async def test_mcp_server_integration():
+    """Test the MCP server directly (requires running server)."""
+    
+    # Get required configuration - fail if not available
+    mcp_api_key = os.getenv("MCP_API_KEY")
+    mcp_server_url = os.getenv("MCP_SERVER_URL")
+    
+    assert mcp_api_key is not None, "MCP_API_KEY must be set in .env file"
+    assert mcp_server_url is not None, "MCP_SERVER_URL must be set in .env file"
+    
+    async with httpx.AsyncClient() as client:
+        # Test without auth - should fail
+        try:
+            resp = await client.get(f"{mcp_server_url}/server_time")
+            assert resp.status_code == 401, f"Expected 401 for unauthorized request, got {resp.status_code}"
+        except httpx.HTTPStatusError as e:
+            assert e.response.status_code == 401, "Should return 401 for unauthorized access"
+        
+        # Test with auth - should succeed (will fail if server not running)
+        headers = {"Authorization": f"Bearer {mcp_api_key}"}
+        resp = await client.get(f"{mcp_server_url}/server_time", headers=headers)
+        assert resp.status_code == 200, f"MCP server failed with {resp.status_code}: {resp.text}"
+        
+        data = resp.json()
+        assert "server_time" in data, "Response should contain 'server_time' field"
+        assert "[MCP Server Time]" in data["server_time"], "Should have MCP identifier"
+        
+        # Verify it's a valid timestamp (basic check)
+        time_str = data["server_time"]
+        assert "T" in time_str and ":" in time_str, f"Should be ISO format timestamp: {time_str}"
+
+@pytest.mark.asyncio
+async def test_api_server_integration():
+    """Test the API server with real OpenAI integration (requires running servers and API key)."""
+    
+    # Check for required environment variables - fail if not available
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    assert openai_api_key is not None, "OPENAI_API_KEY must be set in .env file"
+    assert openai_api_key.startswith("sk-"), f"Invalid OpenAI API key format: {openai_api_key[:10]}..."
+    
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # Test with time-related query - should trigger MCP
+        response = await client.post(
+            "http://localhost:8000/chat",
+            json={"message": "What is the current server time?"}
+        )
+        assert response.status_code == 200, f"API server failed with {response.status_code}: {response.text}"
+        
+        data = response.json()
+        assert "answer" in data, "Response should contain 'answer' field"
+        answer = data["answer"]
+        assert "[MCP Server Time]" in answer, f"Answer should contain MCP time identifier. Got: {answer}"
+        
+        # Test with non-time query - should not trigger MCP
+        response = await client.post(
+            "http://localhost:8000/chat", 
+            json={"message": "Tell me a joke"}
+        )
+        assert response.status_code == 200, f"API server failed with {response.status_code}: {response.text}"
+        
+        data = response.json()
+        assert "answer" in data, "Response should contain 'answer' field"
+        # This should not contain MCP time identifier
+        answer = data["answer"]
+        assert isinstance(answer, str), "Answer should be a string"

--- a/tests/test_tool_flow.py
+++ b/tests/test_tool_flow.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Test the complete tool flow with logging."""
+
+import pytest
+import os
+from dotenv import load_dotenv
+from fastapi_openai_mcp import api_server
+import httpx
+
+# Load environment variables
+load_dotenv()
+
+@pytest.mark.asyncio
+async def test_tool_flow():
+    """Test the complete flow with inline execution (requires OpenAI API key and MCP server)."""
+    
+    # Ensure we have required environment variables - fail if not
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    mcp_api_key = os.getenv("MCP_API_KEY")
+    mcp_server_url = os.getenv("MCP_SERVER_URL")
+    
+    assert openai_api_key is not None, "OPENAI_API_KEY must be set in .env file"
+    assert openai_api_key.startswith("sk-"), f"Invalid OpenAI API key format: {openai_api_key[:10]}..."
+    assert mcp_api_key is not None, "MCP_API_KEY must be set in .env file"
+    assert mcp_server_url is not None, "MCP_SERVER_URL must be set in .env file"
+    
+    # Create a chat request
+    req = api_server.ChatRequest(message="What is the current server time?")
+    
+    # Call the chat endpoint directly - this will fail if OpenAI API key is invalid
+    result = await api_server.chat(req)
+    
+    # Assertions
+    assert "answer" in result, "Result should contain 'answer' field"
+    assert isinstance(result["answer"], str), "Answer should be a string"
+    
+    # Also test the MCP server directly if it's running
+    async with httpx.AsyncClient() as client:
+        mcp_resp = await client.get(
+            f"{mcp_server_url}/server_time",
+            headers={"Authorization": f"Bearer {mcp_api_key}"}
+        )
+        assert mcp_resp.status_code == 200, f"MCP server returned {mcp_resp.status_code}: {mcp_resp.text}"
+        mcp_data = mcp_resp.json()
+        assert "server_time" in mcp_data, "MCP response should contain 'server_time'"
+        assert "[MCP Server Time]" in mcp_data["server_time"], "Response should have MCP identifier"


### PR DESCRIPTION
## Summary
- implement `mcp_server.py` with token protected `/server_time`
- implement `api_server.py` using OpenAI Responses API (`gpt-4-turbo`)
- add typing across the code and tests
- document setup, running, and testing in README

## Testing
- `python -m coverage run -m pytest`
- `python -m coverage report`


------
https://chatgpt.com/codex/tasks/task_e_6884afe4dd68832f8480aaf54cc74ee3